### PR TITLE
Updated terraform version to work with >2.1.19 and recent aiven provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,10 +54,10 @@ avn_pg_svc_plan = "business-4"
 avn_pg_svc_name = "test-pg-debezium-gcp"
 avn_pg_svc_window_dow = "friday"
 avn_pg_svc_window_time = "12:00:00"
-avn_pg_svc_version = "12"
+avn_pg_svc_version = "14"
 
 # Kafka
-avn_kafka_svc_version = "2.7"
+avn_kafka_svc_version = "3.2"
 avn_kafka_svc_project_id = "test-demo"
 avn_kafka_svc_cloud = "google-us-central1"
 avn_kafka_svc_plan = "business-4"

--- a/terraform/postgres/service.tf
+++ b/terraform/postgres/service.tf
@@ -1,11 +1,12 @@
 
 # Postgres
-resource "aiven_service" "avn-us-pg" {
+resource "aiven_pg" "avn-user-pg" {
+#resource "aiven_service" "avn-us-pg" {
   project      = var.avn_pg_svc_project_id
   cloud_name   = var.avn_pg_svc_cloud
   plan         = var.avn_pg_svc_plan
   service_name = var.avn_pg_svc_name
-  service_type = "pg"
+  #service_type = "pg"
   maintenance_window_dow = var.avn_pg_svc_window_dow
   maintenance_window_time = var.avn_pg_svc_window_time
 

--- a/terraform/provider.tf
+++ b/terraform/provider.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aiven = {
       source = "aiven/aiven"
-      version = "2.1.19"
+      version = ">2.1.19"
     }
   }
 }


### PR DESCRIPTION
Updated the following:
- `terraform/provider.tf`: work with recent aiven provider version greater than 2.1.19
- `terraform/postgres/service.tf`: changed resource `aiven_service` to the more recent `aiven_pg`
- `terraform/postgres/service.tf`: removed `service_type` field
- Updated README.md to use the latest PG version 14 and Kafka version 3.2